### PR TITLE
Fix attachments being scaled twice

### DIFF
--- a/Libraries/SpriteTools/Code/SpriteComponent.cs
+++ b/Libraries/SpriteTools/Code/SpriteComponent.cs
@@ -518,7 +518,6 @@ public sealed class SpriteComponent : Component, Component.ExecuteInEditor
             var pos = (new Vector3(attachPos.y, attachPos.x, 0) - (Vector3.One.WithZ(0) / 2f) - new Vector3(origin.y, origin.x, 0)) * 100f;
             pos *= new Vector3(1f, ratio, 1f);
             pos = pos.RotateAround(Vector3.Zero, _rotationOffset);
-            pos *= Transform.LocalScale;
 
             if (SpriteFlags.HasFlag(SpriteFlags.HorizontalFlip)) rot *= Rotation.From(180, 0, 0);
             if (SpriteFlags.HasFlag(SpriteFlags.VerticalFlip)) rot *= Rotation.From(0, 0, 180);


### PR DESCRIPTION
The attachments were being scaled twice. Once by the parent gameobject, and a second time by https://github.com/Facepunch/sbox-spritetools/blob/ad979138cb9044803a7550df10941dbbd4b14b7e/Libraries/SpriteTools/Code/SpriteComponent.cs#L521

Also tested in tilemap-tools.

https://github.com/user-attachments/assets/ec7371cc-5882-4eaa-9752-c7d9ee09b686

[reproduction project.zip](https://github.com/user-attachments/files/16533223/sbox-spritetools.zip)


___

Removing the line makes it work as expected. Haven't encountered any problems during my testing.

https://github.com/user-attachments/assets/245b1056-5362-48b9-ae10-bda7cb18c513