### PR TITLE
Animation Loop Points

### DIFF
--- a/Libraries/SpriteTools/Code/Sprite/SpriteComponent.cs
+++ b/Libraries/SpriteTools/Code/Sprite/SpriteComponent.cs
@@ -481,7 +481,7 @@ public sealed class SpriteComponent : Component, Component.ExecuteInEditor
                 {
                     case SpriteResource.LoopMode.PingPong:
                         _isPingPonging = !_isPingPonging;
-                        frame = loopEnd - 1;
+                        frame = Math.Max(loopEnd - 1, loopStart);
                         break;
                     case SpriteResource.LoopMode.Forward:
                         _isPingPonging = false;
@@ -505,7 +505,7 @@ public sealed class SpriteComponent : Component, Component.ExecuteInEditor
                 {
                     case SpriteResource.LoopMode.PingPong:
                         _isPingPonging = !_isPingPonging;
-                        frame = loopStart + 1;
+                        frame = Math.Min(loopStart + 1, loopEnd);
                         break;
                     case SpriteResource.LoopMode.Forward:
                         _isPingPonging = false;

--- a/Libraries/SpriteTools/Code/Sprite/SpriteComponent.cs
+++ b/Libraries/SpriteTools/Code/Sprite/SpriteComponent.cs
@@ -469,21 +469,23 @@ public sealed class SpriteComponent : Component, Component.ExecuteInEditor
         if (_timeSinceLastFrame < frameRate) return;
         if (!(CurrentAnimation.LoopMode != SpriteResource.LoopMode.None || (currentPlayback > 0 && CurrentFrameIndex < frameCount - 1) || (currentPlayback < 0 && CurrentFrameIndex > 0))) return;
 
+        var loopStart = CurrentAnimation.GetLoopStart();
+        var loopEnd = CurrentAnimation.GetLoopEnd();
         if (currentPlayback > 0)
         {
             var frame = CurrentFrameIndex;
             frame++;
-            if (frame >= frameCount && CurrentAnimation.LoopMode != SpriteResource.LoopMode.None)
+            if (frame > loopEnd && CurrentAnimation.LoopMode != SpriteResource.LoopMode.None)
             {
                 switch (CurrentAnimation.LoopMode)
                 {
                     case SpriteResource.LoopMode.PingPong:
                         _isPingPonging = !_isPingPonging;
-                        frame = frameCount - 2;
+                        frame = loopEnd - 1;
                         break;
                     case SpriteResource.LoopMode.Forward:
                         _isPingPonging = false;
-                        frame = 0;
+                        frame = loopStart;
                         break;
                 }
             }
@@ -497,17 +499,17 @@ public sealed class SpriteComponent : Component, Component.ExecuteInEditor
         {
             var frame = CurrentFrameIndex;
             frame--;
-            if (CurrentAnimation.LoopMode != SpriteResource.LoopMode.None && frame < 0)
+            if (frame < loopStart && CurrentAnimation.LoopMode != SpriteResource.LoopMode.None)
             {
                 switch (CurrentAnimation.LoopMode)
                 {
                     case SpriteResource.LoopMode.PingPong:
                         _isPingPonging = !_isPingPonging;
-                        frame = 1;
+                        frame = loopStart + 1;
                         break;
                     case SpriteResource.LoopMode.Forward:
                         _isPingPonging = false;
-                        frame = frameCount - 1;
+                        frame = loopEnd;
                         break;
                 }
             }

--- a/Libraries/SpriteTools/Code/Sprite/SpriteResource.cs
+++ b/Libraries/SpriteTools/Code/Sprite/SpriteResource.cs
@@ -173,6 +173,18 @@ public class SpriteAnimation
 		Attachments = new List<SpriteAttachment>();
 	}
 
+	public int GetLoopStart()
+	{
+		if (LoopStart is null) return 0;
+		return LoopStart.Value;
+	}
+
+	public int GetLoopEnd()
+	{
+		if (LoopEnd is null) return Frames.Count - 1;
+		return LoopEnd.Value;
+	}
+
 	public Vector2 GetAttachmentPosition(string attachment, int index)
 	{
 		var attach = Attachments?.FirstOrDefault(x => x.Name == attachment);

--- a/Libraries/SpriteTools/Code/Sprite/SpriteResource.cs
+++ b/Libraries/SpriteTools/Code/Sprite/SpriteResource.cs
@@ -157,6 +157,9 @@ public class SpriteAnimation
 	/// </summary>
 	public List<SpriteAttachment> Attachments { get; set; } = new();
 
+	public int? LoopStart { get; set; } = null;
+	public int? LoopEnd { get; set; } = null;
+
 	public SpriteAnimation()
 	{
 		Frames = new List<SpriteAnimationFrame>();

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/MainWindow.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/MainWindow.cs
@@ -493,6 +493,7 @@ public partial class MainWindow : DockWindow, IAssetEditor
 
     public void PlayPause()
     {
+        _isPingPonging = false;
         Playing = !Playing;
         if (Playing && SelectedAnimation.LoopMode == SpriteResource.LoopMode.None && CurrentFrameIndex >= SelectedAnimation.Frames.Count - 1)
         {

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/MainWindow.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/MainWindow.cs
@@ -359,7 +359,7 @@ public partial class MainWindow : DockWindow, IAssetEditor
             else if (SelectedAnimation.LoopMode == SpriteResource.LoopMode.PingPong)
             {
                 _isPingPonging = true;
-                nextFrame = loopEnd - 1;
+                nextFrame = Math.Max(loopEnd - 1, loopStart);
             }
             else if (nextFrame >= SelectedAnimation.Frames.Count)
             {
@@ -376,7 +376,7 @@ public partial class MainWindow : DockWindow, IAssetEditor
             else if (SelectedAnimation.LoopMode == SpriteResource.LoopMode.PingPong)
             {
                 _isPingPonging = false;
-                nextFrame = loopStart + 1;
+                nextFrame = Math.Min(loopStart + 1, loopEnd);
             }
             else
             {

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/MainWindow.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/MainWindow.cs
@@ -348,33 +348,35 @@ public partial class MainWindow : DockWindow, IAssetEditor
     {
         var playbackSpeed = _isPingPonging ? -1 : 1;
         var nextFrame = CurrentFrameIndex + playbackSpeed;
-        if (nextFrame >= SelectedAnimation.Frames.Count)
+        var loopStart = SelectedAnimation.GetLoopStart();
+        var loopEnd = SelectedAnimation.GetLoopEnd();
+        if (nextFrame > loopEnd && playbackSpeed > 0)
         {
             if (SelectedAnimation.LoopMode == SpriteResource.LoopMode.Forward)
             {
-                nextFrame = 0;
+                nextFrame = loopStart;
             }
             else if (SelectedAnimation.LoopMode == SpriteResource.LoopMode.PingPong)
             {
                 _isPingPonging = true;
-                nextFrame = SelectedAnimation.Frames.Count - 2;
+                nextFrame = loopEnd - 1;
             }
-            else
+            else if (nextFrame >= SelectedAnimation.Frames.Count)
             {
                 nextFrame = SelectedAnimation.Frames.Count - 1;
                 PlayPause();
             }
         }
-        else if (nextFrame < 0)
+        else if (nextFrame < loopStart && playbackSpeed < 0)
         {
             if (SelectedAnimation.LoopMode == SpriteResource.LoopMode.Forward)
             {
-                nextFrame = SelectedAnimation.Frames.Count - 1;
+                nextFrame = loopEnd;
             }
             else if (SelectedAnimation.LoopMode == SpriteResource.LoopMode.PingPong)
             {
                 _isPingPonging = false;
-                nextFrame = 1;
+                nextFrame = loopStart + 1;
             }
             else
             {

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Preview/Preview.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Preview/Preview.cs
@@ -120,6 +120,8 @@ public class Preview : Widget
         if (MainWindow.Sprite is null) return;
         if (MainWindow.SelectedAnimation is null) return;
         if (MainWindow.SelectedAnimation.Frames.Count <= 0) return;
+        if (MainWindow.CurrentFrameIndex < 0) return;
+        if (MainWindow.CurrentFrameIndex >= MainWindow.SelectedAnimation.Frames.Count) return;
         var frame = MainWindow.SelectedAnimation.Frames[MainWindow.CurrentFrameIndex];
         if (frame is null) return;
         if (!Sandbox.FileSystem.Mounted.FileExists(frame.FilePath)) return;

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
@@ -19,7 +19,7 @@ public class FrameButton : Widget
     Drag dragData;
     bool draggingAbove = false;
     bool draggingBelow = false;
-    bool draggingLoopPoint = false;
+    int draggingLoopPoint = 0;
     bool draggingLoopPointStart = false;
     bool draggingLoopPointEnd = false;
 
@@ -153,17 +153,19 @@ public class FrameButton : Widget
             var headerWidth = 4f;
             var isStart = anim.GetLoopStart() == FrameIndex;
             var isEnd = anim.GetLoopEnd() == FrameIndex;
-            var alpha = (!(dragData?.IsValid ?? false) || draggingLoopPointStart || draggingLoopPointEnd) ? 0.5f : 0.25f;
-            Paint.SetPen(Theme.Yellow.WithAlpha(alpha), headerWidth * 2f);
             if (isStart || draggingLoopPointStart)
             {
+                var alpha = (!((dragData?.IsValid ?? false) && dragData.Data.Text == "loop-start") || draggingLoopPointStart) ? 0.5f : 0.25f;
+                Paint.SetPen(Theme.Yellow.WithAlpha(alpha), headerWidth * 2f);
                 Paint.DrawLine(LocalRect.TopLeft, LocalRect.BottomLeft);
                 Paint.ClearPen();
                 Paint.SetBrush(Theme.Yellow.WithAlpha(alpha));
                 Paint.DrawPolygon([LocalRect.TopLeft + new Vector2(headerWidth, 0), LocalRect.TopLeft + new Vector2(headerWidth, headerSize), LocalRect.TopLeft + new Vector2(headerWidth + headerSize, headerSize / 2f)]);
             }
-            else if (isEnd || draggingLoopPointEnd)
+            if (isEnd || draggingLoopPointEnd)
             {
+                var alpha = (!((dragData?.IsValid ?? false) && dragData.Data.Text == "loop-end") || draggingLoopPointEnd) ? 0.5f : 0.25f;
+                Paint.SetPen(Theme.Yellow.WithAlpha(alpha), headerWidth * 2f);
                 Paint.DrawLine(LocalRect.TopRight, LocalRect.BottomRight);
                 Paint.ClearPen();
                 Paint.SetBrush(Theme.Yellow.WithAlpha(alpha));
@@ -189,9 +191,9 @@ public class FrameButton : Widget
 
         dragData = new Drag(this);
 
-        if (draggingLoopPoint)
+        if (draggingLoopPoint != 0)
         {
-            dragData.Data.Text = (MainWindow.SelectedAnimation.GetLoopStart() == FrameIndex) ? "loop-start" : "loop-end";
+            dragData.Data.Text = (draggingLoopPoint == 1) ? "loop-start" : "loop-end";
         }
         else
         {
@@ -295,8 +297,18 @@ public class FrameButton : Widget
         base.OnMousePress(e);
 
         var anim = MainWindow.SelectedAnimation;
-        draggingLoopPoint = (anim.GetLoopStart() == FrameIndex && e.LocalPosition.x < 8) || (anim.GetLoopEnd() == FrameIndex && e.LocalPosition.x > Width - 8);
-        Log.Info($"Dragging Loop Point: {draggingLoopPoint}");
+        if (anim.GetLoopStart() == FrameIndex && e.LocalPosition.x < 8)
+        {
+            draggingLoopPoint = 1;
+        }
+        else if (anim.GetLoopEnd() == FrameIndex && e.LocalPosition.x > Width - 8)
+        {
+            draggingLoopPoint = 2;
+        }
+        else
+        {
+            draggingLoopPoint = 0;
+        }
     }
 
     protected override void OnMouseClick(MouseEvent e)

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
@@ -237,11 +237,15 @@ public class FrameButton : Widget
         {
             if (ev.Data.Text == "loop-start")
             {
+                MainWindow.PushUndo($"Change {MainWindow.SelectedAnimation.Name} Loop Start");
                 MainWindow.SelectedAnimation.LoopStart = FrameIndex;
+                MainWindow.PushRedo();
             }
             else if (ev.Data.Text == "loop-end")
             {
+                MainWindow.PushUndo($"Change {MainWindow.SelectedAnimation.Name} Loop End");
                 MainWindow.SelectedAnimation.LoopEnd = FrameIndex;
+                MainWindow.PushRedo();
             }
 
             return;

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
@@ -81,6 +81,7 @@ public class FrameButton : Widget
     protected override void OnPaint()
     {
         bool isSelected = Selected.Contains(this);
+        var anim = MainWindow.SelectedAnimation;
 
         MinimumSize = new Vector2(FrameSize, FrameSize + 16f);
         MaximumSize = new Vector2(FrameSize, FrameSize + 16f);
@@ -124,13 +125,13 @@ public class FrameButton : Widget
         }
         Paint.Draw(pixRect, Pixmap);
 
-        if (MainWindow.SelectedAnimation.Frames[FrameIndex].Events.Count > 0)
+        if (anim.Frames[FrameIndex].Events.Count > 0)
         {
             var tagRect = new Rect(LocalRect.BottomLeft + Vector2.Down * 20f, new Vector2(Width, 20f)).Shrink(4);
             Paint.SetBrushAndPen(Theme.Yellow.WithAlpha(0.5f));
             Paint.DrawRect(tagRect);
 
-            string events = string.Join(", ", MainWindow.SelectedAnimation.Frames[FrameIndex].Events);
+            string events = string.Join(", ", anim.Frames[FrameIndex].Events);
 
             Paint.SetFont("Poppins", 7, 1000, false);
             Paint.SetPen(Theme.Black);
@@ -142,6 +143,27 @@ public class FrameButton : Widget
         }
 
         base.OnPaint();
+
+        if (anim.LoopMode != SpriteResource.LoopMode.None)
+        {
+            var headerSize = 16f;
+            var headerWidth = 4f;
+            Paint.SetPen(Theme.Yellow.WithAlpha(0.5f), headerWidth * 2f);
+            if (anim.GetLoopStart() == FrameIndex)
+            {
+                Paint.DrawLine(LocalRect.TopLeft, LocalRect.BottomLeft);
+                Paint.ClearPen();
+                Paint.SetBrush(Theme.Yellow.WithAlpha(0.5f));
+                Paint.DrawPolygon([LocalRect.TopLeft + new Vector2(headerWidth, 0), LocalRect.TopLeft + new Vector2(headerWidth, headerSize), LocalRect.TopLeft + new Vector2(headerWidth + headerSize, headerSize / 2f)]);
+            }
+            else if (anim.GetLoopEnd() == FrameIndex)
+            {
+                Paint.DrawLine(LocalRect.TopRight, LocalRect.BottomRight);
+                Paint.ClearPen();
+                Paint.SetBrush(Theme.Yellow.WithAlpha(0.5f));
+                Paint.DrawPolygon([LocalRect.TopRight - new Vector2(headerWidth, 0), LocalRect.TopRight + new Vector2(-headerWidth, headerSize), LocalRect.TopRight + new Vector2(-(headerWidth + headerSize), headerSize / 2f)]);
+            }
+        }
 
         if (draggingAbove)
         {

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/FrameButton.cs
@@ -297,11 +297,11 @@ public class FrameButton : Widget
         base.OnMousePress(e);
 
         var anim = MainWindow.SelectedAnimation;
-        if (anim.GetLoopStart() == FrameIndex && e.LocalPosition.x < 8)
+        if (anim.GetLoopStart() == FrameIndex && e.LocalPosition.x < 12)
         {
             draggingLoopPoint = 1;
         }
-        else if (anim.GetLoopEnd() == FrameIndex && e.LocalPosition.x > Width - 8)
+        else if (anim.GetLoopEnd() == FrameIndex && e.LocalPosition.x > Width - 12)
         {
             draggingLoopPoint = 2;
         }

--- a/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/Timeline.cs
+++ b/Libraries/SpriteTools/Editor/Sprite/SpriteEditor/Timeline/Timeline.cs
@@ -165,6 +165,15 @@ public class Timeline : Widget
             }
         }
 
+        if (MainWindow.SelectedAnimation.LoopStart is not null && MainWindow.SelectedAnimation.LoopStart < 0)
+        {
+            MainWindow.SelectedAnimation.LoopStart = null;
+        }
+        if (MainWindow.SelectedAnimation.LoopEnd is not null && MainWindow.SelectedAnimation.LoopEnd >= MainWindow.SelectedAnimation.Frames.Count)
+        {
+            MainWindow.SelectedAnimation.LoopEnd = null;
+        }
+
         var addButton = new IconButton("add");
         addButton.Width = 128;
         addButton.Height = 128;

--- a/Libraries/SpriteTools/spritetools.sbproj
+++ b/Libraries/SpriteTools/spritetools.sbproj
@@ -8,7 +8,8 @@
   "Resources": null,
   "PackageReferences": [],
   "EditorReferences": null,
-  "IsWhitelistDisabled": false,
+  "Mounts": null,
+  "IsStandaloneOnly": false,
   "Metadata": {
     "CsProjName": ""
   }


### PR DESCRIPTION
Resolves #33 

# Changes

Adds loop points to animations so you can have frames that lead into the loop or exit from it when looping is disabled. Works with Ping Pong mode and has two draggable indicators on the FrameButtons in the Timeline. These are only visible if Looping is not set to None.

https://github.com/user-attachments/assets/8295a86a-4f90-4fc3-bdaa-3fa555841992

